### PR TITLE
Change nord_cloze.css to render cloze bolded

### DIFF
--- a/nord_cloze.css
+++ b/nord_cloze.css
@@ -126,6 +126,7 @@ html:not(.mobile) .card {
 .cloze {
   background-color: var(--cloze-bg);
   color: var(--cloze-fg);
+  font-weight: bold;
 }
 
 /* -------------------------------------------------- DECK */


### PR DESCRIPTION
Add font-weight property to cloze class in nord_cloze.css to render cloze text as bold.

* Modify `nord_cloze.css` to include `font-weight: bold;` in the `.cloze` class.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/slaterpeter/anki-note-types/pull/1?shareId=e480623d-caa9-486d-ab66-8d6c6ba0133e).